### PR TITLE
New Feature: Allow customizing the list of character hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If a key is not found in the config file nor provided as a cli option, then it u
 An example config is with the default options is shown below:
 
 ```yaml
+chars: 'fjghdkslaemuvitywoqpcbnxz'
+
 window_background_color: '1d1f21'
 window_background_opacity: 0.2
 
@@ -41,6 +43,8 @@ A tool to help efficiently focus windows in Sway inspired by i3-easyfocus.
 Usage: sway-easyfocus [OPTIONS]
 
 Options:
+      --chars <CHARS>
+          list of chars to use for hints <fjghdkslaemuvitywoqpcbnxz>
       --window-background-color <WINDOW_BACKGROUND_COLOR>
           set the window background color <rrggbb>
       --window-background-opacity <WINDOW_BACKGROUND_OPACITY>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,10 @@ use serde::Deserialize;
 #[derive(Parser, Deserialize, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// list of chars to use for hints <fjghdkslaemuvitywoqpcbnxz>
+    #[arg(long)]
+    pub chars: Option<String>,
+
     /// set the window background color <rrggbb>
     #[arg(long)]
     pub window_background_color: Option<String>,
@@ -121,6 +125,7 @@ impl Args {
 impl Default for Args {
     fn default() -> Self {
         Self {
+            chars: Some("fjghdkslaemuvitywoqpcbnxz".to_string()),
             window_background_color: Some("1d1f21".to_string()),
             window_background_opacity: Some(0.2),
             label_background_color: Some("1d1f21".to_string()),

--- a/src/sway.rs
+++ b/src/sway.rs
@@ -63,8 +63,7 @@ pub fn get_all_windows(workspace: &Node) -> Vec<Node> {
     nodes
 }
 
-pub fn focus(conn: Arc<Mutex<Connection>>, windows: &[Node], idx: usize) {
-    let con_id = windows[idx].id;
+pub fn focus(conn: Arc<Mutex<Connection>>, con_id: i64) {
     let mut conn_lock = conn.lock().unwrap();
     conn_lock
         .run_command(format!("[con_id={}] focus", con_id))


### PR DESCRIPTION
Also, removes the hack to look up windows to focus.

Still limited to 26 windows by default, but could define additional
characters in your config file, including numbers and symbols in theory.
