### PR TITLE
WIP: multi-monitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If a key is not found in the config file nor provided as a cli option, then it u
 An example config is with the default options is shown below:
 
 ```yaml
+chars: 'fjghdkslaemuvitywoqpcbnxz'
+
 window_background_color: '1d1f21'
 window_background_opacity: 0.2
 
@@ -41,6 +43,8 @@ A tool to help efficiently focus windows in Sway inspired by i3-easyfocus.
 Usage: sway-easyfocus [OPTIONS]
 
 Options:
+      --chars <CHARS>
+          list of chars to use for hints <fjghdkslaemuvitywoqpcbnxz>
       --window-background-color <WINDOW_BACKGROUND_COLOR>
           set the window background color <rrggbb>
       --window-background-opacity <WINDOW_BACKGROUND_OPACITY>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,10 @@ use serde::Deserialize;
 #[derive(Parser, Deserialize, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// list of chars to use for hints <fjghdkslaemuvitywoqpcbnxz>
+    #[arg(long)]
+    pub chars: Option<String>,
+
     /// set the window background color <rrggbb>
     #[arg(long)]
     pub window_background_color: Option<String>,
@@ -121,6 +125,7 @@ impl Args {
 impl Default for Args {
     fn default() -> Self {
         Self {
+            chars: Some("fjghdkslaemuvitywoqpcbnxz".to_string()),
             window_background_color: Some("1d1f21".to_string()),
             window_background_opacity: Some(0.2),
             label_background_color: Some("1d1f21".to_string()),

--- a/src/sway.rs
+++ b/src/sway.rs
@@ -63,8 +63,7 @@ pub fn get_all_windows(workspace: &Node) -> Vec<Node> {
     nodes
 }
 
-pub fn focus(conn: Arc<Mutex<Connection>>, windows: &[Node], idx: usize) {
-    let con_id = windows[idx].id;
+pub fn focus(conn: Arc<Mutex<Connection>>, con_id: i64) {
     let mut conn_lock = conn.lock().unwrap();
     conn_lock
         .run_command(format!("[con_id={}] focus", con_id))

--- a/src/sway.rs
+++ b/src/sway.rs
@@ -16,11 +16,29 @@ pub fn get_tree(conn: Arc<Mutex<Connection>>) -> Node {
         .expect("failed to communicate with sway")
 }
 
-pub fn get_focused_output(conn: Arc<Mutex<Connection>>) -> Node {
+// All output nodes, focused or not
+pub fn get_all_output_nodes(conn: Arc<Mutex<Connection>>) -> Vec<Node> {
+    let mut output_nodes = vec![];
+    let mut q = VecDeque::new();
     let root_node = get_tree(conn);
-    root_node
-        .find_focused(|n| n.node_type == swayipc::NodeType::Output)
-        .expect("could not find focused output")
+
+    q.push_back(root_node);
+
+    while !q.is_empty() {
+        // We can unwrap because we know the queue is not empty
+        let node = q.pop_back().unwrap();
+
+        // If we hav an output node
+        if (node.node_type == NodeType::Output) && !node.nodes.is_empty() {
+            output_nodes.push(node.clone());
+        }
+
+        // Look for more outputs in the children
+        for child in node.nodes {
+            q.push_back(child.clone());
+        }
+    }
+    output_nodes
 }
 
 pub fn get_focused_workspace(output: &Node) -> Node {
@@ -30,7 +48,7 @@ pub fn get_focused_workspace(output: &Node) -> Node {
         .expect("could not find focused workspace")
 }
 
-pub fn get_all_windows(workspace: &Node) -> Vec<Node> {
+pub fn get_window_nodes_for_one_workspace(workspace: &Node) -> Vec<Node> {
     let mut nodes = vec![];
 
     let mut q = VecDeque::new();
@@ -52,7 +70,7 @@ pub fn get_all_windows(workspace: &Node) -> Vec<Node> {
         }
 
         /*
-        // floating nodes
+        // TODO: floating nodes
         for child in node.floating_nodes {
             q.push_back(child.clone());
         }
@@ -63,9 +81,8 @@ pub fn get_all_windows(workspace: &Node) -> Vec<Node> {
     nodes
 }
 
-pub fn focus(conn: Arc<Mutex<Connection>>, con_id: i64) {
-    let mut conn_lock = conn.lock().unwrap();
-    conn_lock
+pub fn focus(con_id: i64) {
+    acquire_connection()
         .run_command(format!("[con_id={}] focus", con_id))
         .expect("failed to focus container");
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -21,77 +21,88 @@ fn calculate_geometry(window: &Node, output: &Node, args: Arc<Args>) -> (i32, i3
     (rel_x - anchor_x, rel_y - anchor_y)
 }
 
-fn handle_keypress(conn: Arc<Mutex<Connection>>, key_to_con_id: &HashMap<char, i64>, keyval: &str) {
+// TODO: Currently this only closes the windows on a single output.
+// It needs to close the windows on all three outputs
+fn handle_keypress(key_to_con_id: &HashMap<char, i64>, keyval: &str) {
     if keyval.len() == 1 {
         // we can unwrap because the keyval has one character
         let c = keyval.chars().next().unwrap();
         if c.is_alphabetic() && c.is_lowercase() {
             let con_id = key_to_con_id[&c];
-            sway::focus(conn, con_id);
+            sway::focus(con_id);
         }
+        std::process::exit(0);
     }
 }
 
 fn build_ui(app: &Application, args: Arc<Args>, conn: Arc<Mutex<Connection>>) {
+
     // get windows from sway
-    let output = sway::get_focused_output(conn.clone());
-    let workspace = sway::get_focused_workspace(&output);
-    let windows = sway::get_all_windows(&workspace);
+    let output_nodes = sway::get_all_output_nodes(conn.clone());
 
     let letters = args.chars.clone().expect("Some characters are required");
     let mut chars = letters.chars();
 
-    // exit if no windows open
-    if windows.len() == 0 {
-        return;
-    }
+    // Create one "window" for each output each with its own keypress handler.
+    for output in output_nodes {
+        let workspace = sway::get_focused_workspace(&output);
+        let sway_windows = sway::get_window_nodes_for_one_workspace(&workspace);
 
-    let window = gtk::ApplicationWindow::new(app);
-
-    // before the window is first realized, set it up to be a layer surface
-    gtk_layer_shell::init_for_window(&window);
-    // display it above normal windows
-    gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay);
-
-    // receive keyboard events from the compositor
-    gtk_layer_shell::set_keyboard_mode(&window, gtk_layer_shell::KeyboardMode::Exclusive);
-
-    // take up the full screen
-    gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, true);
-    gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Bottom, true);
-    gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Left, true);
-    gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Right, true);
-
-    let fixed = gtk::Fixed::new();
-    // map keys to window Ids
-    let mut key_to_con_id = HashMap::new();
-
-    for (_idx, window) in windows.iter().enumerate() {
-        let (x, y) = calculate_geometry(window, &output, args.clone());
-        let label = gtk::Label::new(Some(""));
-        let letter = chars.next().unwrap();
-        key_to_con_id.insert(letter, window.id);
-        label.set_markup(&format!("{}", letter));
-        fixed.put(&label, x, y);
-
-        // Apply a CSS class to the focused window so it can be styled differently
-        if window.focused {
-            label.style_context().add_class("focused");
+        // exit if no sway_windows open
+        if sway_windows.len() == 0 {
+            return;
         }
+
+        // TODO: Every GTK is getting opened on the current output
+        // Use the Sway "output" details to decide where to place the window.
+        let window = gtk::ApplicationWindow::new(app);
+
+        // before the window is first realized, set it up to be a layer surface
+        gtk_layer_shell::init_for_window(&window);
+        // display it above normal sway_windows
+        gtk_layer_shell::set_layer(&window, gtk_layer_shell::Layer::Overlay);
+
+        // receive keyboard events from the compositor
+        gtk_layer_shell::set_keyboard_mode(&window, gtk_layer_shell::KeyboardMode::Exclusive);
+
+        // take up the full screen
+        gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Top, true);
+        gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Bottom, true);
+        gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Left, true);
+        gtk_layer_shell::set_anchor(&window, gtk_layer_shell::Edge::Right, true);
+
+        let fixed = gtk::Fixed::new();
+        // map keys to window Ids
+        let mut key_to_con_id = HashMap::new();
+
+        for (_idx, window) in sway_windows.iter().enumerate() {
+            let (x, y) = calculate_geometry(window, &output, args.clone());
+            let label = gtk::Label::new(Some(""));
+            let letter = chars.next().unwrap();
+            key_to_con_id.insert(letter, window.id);
+            label.set_markup(&format!("{}", letter));
+            fixed.put(&label, x, y);
+
+            // Apply a CSS class to the focused window so it can be styled differently
+            if window.focused {
+                label.style_context().add_class("focused");
+            }
+        }
+
+        // TODO: close windows on all outputs
+        window.connect_key_press_event(move |window, event| {
+            let keyval = event
+                .keyval()
+                .name()
+                .expect("the key pressed does not have a name?");
+            handle_keypress(&key_to_con_id, &keyval);
+            window.close();
+            Inhibit(false)
+        });
+
+        window.add(&fixed);
+        window.show_all();
     }
-
-    window.connect_key_press_event(move |window, event| {
-        let keyval = event
-            .keyval()
-            .name()
-            .expect("the key pressed does not have a name?");
-        handle_keypress(conn.clone(), &key_to_con_id, &keyval);
-        window.close();
-        Inhibit(false)
-    });
-
-    window.add(&fixed);
-    window.show_all();
 }
 
 fn load_css(args: Arc<Args>) {


### PR DESCRIPTION
This contains the "custom char list commit", because this branch builds on that one.

## What works

 * Details about each output are collected, windows and drawn and
   keypresses are handled.
 * Character hints are unique across outputs.

## What doesn't

 * All the overlays are drawn on the same output instead instead of
   diferrent ones.
 * Pressing a key is only closing the hints on a single output. So, if
   if you have three monitors, it takes three key presses to exit.

## Help wanted

 * I couldn't figure out the Rust memory managent to pass around the
   Sway IPC connection through a "for" loop with closures. So in
   sway::focus(), I just re-connected. That solved the problem and
   I can't tell a noticable difference in performance, but maybe
   there's a better way.
 * I had difficulty locating the Rust GTK docs for how to open an
   overlay window on a different output and am pausing for now.

Feel free to pick up the branch and keep working on it.