### PR TITLE
Add the ability to swap windows, or print the selected container ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ label_margin_y: 2
 ```
 A tool to help efficiently focus windows in Sway inspired by i3-easyfocus.
 
-Usage: sway-easyfocus [OPTIONS]
+Usage: sway-easyfocus [OPTIONS] [COMMAND]
+
+Commands:
+  focus  Focus the selected window (default)
+  swap   Swap focused window with the selected window
+  print  Print the selected window's ID
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
       --chars <CHARS>
@@ -80,6 +86,11 @@ Options:
   -V, --version
           Print version
 ```
+
+The default action is to focus the selected window.  The `swap`
+command can be used to swap the focused window with the selected
+window, and the `print` command can be used to print the selected
+window ID (sway container ID).
 
 ## Build
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,26 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use serde::Deserialize;
+
+/// What to do with the selected container.
+#[derive(Subcommand, Deserialize, Debug, Clone, Copy)]
+pub enum Command {
+    /// Focus the container
+    #[command(about = "Focus the selected window (default)")]
+    Focus,
+
+    /// Swap current window with selected window
+    #[command(about = "Swap focused window with the selected window")]
+    Swap {
+        /// Also focus the selected window after swapping
+        #[arg(long)]
+        focus: bool,
+    },
+
+    /// Print the container's ID
+    #[command(about = "Print the selected window's ID")]
+    Print,
+}
 
 /// A tool to help efficiently focus windows in Sway inspired by i3-easyfocus.
 #[derive(Parser, Deserialize, Debug, Clone)]
@@ -69,6 +89,11 @@ pub struct Args {
     /// set the label margin-y <px>
     #[arg(long)]
     pub label_margin_y: Option<i32>,
+
+    /// The selected command
+    #[command(subcommand)]
+    #[serde(skip)]
+    pub command: Option<Command>,
 }
 
 impl Args {
@@ -122,6 +147,9 @@ impl Args {
         if other.label_margin_y.is_some() {
             self.label_margin_y = other.label_margin_y;
         }
+        if other.command.is_some() {
+            self.command = other.command;
+        }
     }
 }
 
@@ -144,6 +172,7 @@ impl Default for Args {
             label_padding_y: Some(0),
             label_margin_x: Some(4),
             label_margin_y: Some(2),
+            command: Some(Command::Focus),
         }
     }
 }

--- a/src/sway.rs
+++ b/src/sway.rs
@@ -80,3 +80,10 @@ pub fn focus(conn: Arc<Mutex<Connection>>, con_id: i64) {
         .run_command(format!("[con_id={}] focus", con_id))
         .expect("failed to focus container");
 }
+
+pub fn swap(conn: Arc<Mutex<Connection>>, con_id: i64) {
+    let mut conn_lock = conn.lock().unwrap();
+    conn_lock
+        .run_command(format!("swap container with con_id {}", con_id))
+        .expect("failed to swap container");
+}


### PR DESCRIPTION
The user interface for this tool is great for focusing windows far away from the currently focused window.  But, it's also great for swapping windows!

This change adds the ability to perform actions other than focusing (but focusing remains the default and is completely backwards compatible):

  * swap: Swap the focused window with the selected window.

  * print: Print the container ID of the selected window.  Useful for scripting and unexpected uses of this tool.